### PR TITLE
chore: Integrate into Backstage Developer Portal

### DIFF
--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -1,0 +1,20 @@
+name: Validate Catalog info
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'catalog-info.yml'
+      - '.github/workflows/validate-catalog.yml'
+
+jobs:
+  validate_catalog:
+    runs-on: ubuntu-latest
+    steps:
+      - id: 'Checkout'
+        uses: actions/checkout@v4
+
+      - id: 'Validate'
+        uses: 'RoadieHQ/backstage-entity-validator@v0.5.0'
+        with:
+          path: catalog-info.yml

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -7,5 +7,5 @@ metadata:
   description: A micro library providing Ruby objects with Publish-Subscribe capabilities
 spec:
   type: library
-  owner: group:healthcare-developers-platform
+  owner: group:healthcare-developers-logistiek
   lifecycle: production

--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,11 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  title: Wisper
+  name: wisper-compat
+  description: A micro library providing Ruby objects with Publish-Subscribe capabilities
+spec:
+  type: library
+  owner: group:healthcare-developers-platform
+  lifecycle: production


### PR DESCRIPTION
See https://backstage.nedap.software/, https://decisions.nedap.healthcare/t/backstage-as-the-developer-portal/724 and https://decisions.nedap.healthcare/t/replace-hc-assets-with-backstage/742/4

Part of https://github.com/nedap/platform-tribe/issues/1930

This pull request integrates this library into the Backstage Developer Portal.

Goal: make the library and related repository discoverable for developers.

Changes:
- Add a `catalog-info.yml` file that contains metadata about the library. Documentation about the content of the file is available in https://backstage.nedap.software/docs/default/component/hc-backstage/how-to/software-catalog/. If needed, the file can be expanded in the future with more details. For now, the most important thing is that it exists.
- Add a workflow to validate the contents of the catalog file.